### PR TITLE
Small fixes to run this code in 2023

### DIFF
--- a/building_boundary/core/segmentation.py
+++ b/building_boundary/core/segmentation.py
@@ -277,7 +277,7 @@ def boundary_segmentation(points, distance):
     shift = np.min(points_shifted, axis=0)
     points_shifted -= shift
 
-    mask = np.ones(len(points_shifted), dtype=np.bool)
+    mask = np.ones(len(points_shifted), dtype=bool)
     indices = np.arange(len(points_shifted))
 
     segments = []

--- a/building_boundary/shapes/alpha_shape.py
+++ b/building_boundary/shapes/alpha_shape.py
@@ -14,10 +14,10 @@ try:
     from CGAL.CGAL_Alpha_shape_2 import Alpha_shape_2
     from CGAL.CGAL_Alpha_shape_2 import REGULAR
     CGAL_AVAILABLE = True
-    cascaded_union = None
+    unary_union = None
     Delaunay = None
 except ImportError:
-    from shapely.ops import cascaded_union
+    from shapely.ops import unary_union
     from scipy.spatial import Delaunay
     CGAL_AVAILABLE = False
     Point_2 = None
@@ -144,7 +144,7 @@ def alpha_shape_python(points, alpha):
             if circum_r < 1.0 / alpha:
                 triangles.append(Polygon(points[t]))
 
-    alpha_shape = cascaded_union(triangles)
+    alpha_shape = unary_union(triangles)
     if type(alpha_shape) == MultiPolygon:
         alpha_shape = MultiPolygon([Polygon(s.exterior) for s in alpha_shape])
     else:

--- a/building_boundary/shapes/alpha_shape.py
+++ b/building_boundary/shapes/alpha_shape.py
@@ -110,7 +110,11 @@ def triangle_geometry(triangle):
     # Semiperimeter of triangle
     s = (a + b + c) / 2.0
     # Area of triangle by Heron's formula
-    area = math.sqrt(s * (s - a) * (s - b) * (s - c))
+    area = 0
+    try:
+        area = math.sqrt(s * (s - a) * (s - b) * (s - c))
+    except ValueError:
+        pass
     if area != 0:
         circum_r = (a * b * c) / (4.0 * area)
     else:

--- a/building_boundary/shapes/alpha_shape.py
+++ b/building_boundary/shapes/alpha_shape.py
@@ -146,7 +146,7 @@ def alpha_shape_python(points, alpha):
 
     alpha_shape = unary_union(triangles)
     if type(alpha_shape) == MultiPolygon:
-        alpha_shape = MultiPolygon([Polygon(s.exterior) for s in alpha_shape])
+        alpha_shape = MultiPolygon([Polygon(s.exterior) for s in alpha_shape.geoms])
     else:
         alpha_shape = Polygon(alpha_shape.exterior)
 

--- a/building_boundary/shapes/fit.py
+++ b/building_boundary/shapes/fit.py
@@ -48,7 +48,7 @@ def compute_shape(points, alpha=None, k=None):
             shape = unary_union([shape, shape_ch])
 
         if type(shape) != Polygon:
-            shape = max(shape, key=lambda s: s.area)
+            shape = max(shape.geoms, key=lambda s: s.area)
 
     elif k is not None:
         boundary_points = concave_hull.compute(points, k, True)

--- a/building_boundary/shapes/fit.py
+++ b/building_boundary/shapes/fit.py
@@ -7,7 +7,7 @@
 import numpy as np
 from scipy.spatial import ConvexHull
 from shapely.geometry import Polygon
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 import concave_hull
 
@@ -45,7 +45,7 @@ def compute_shape(points, alpha=None, k=None):
         if k is not None:
             boundary_points = concave_hull.compute(points, k, True)
             shape_ch = Polygon(boundary_points).buffer(0)
-            shape = cascaded_union([shape, shape_ch])
+            shape = unary_union([shape, shape_ch])
 
         if type(shape) != Polygon:
             shape = max(shape, key=lambda s: s.area)

--- a/building_boundary/shapes/fit.py
+++ b/building_boundary/shapes/fit.py
@@ -45,7 +45,8 @@ def compute_shape(points, alpha=None, k=None):
         if k is not None:
             boundary_points = concave_hull.compute(points, k, True)
             shape_ch = Polygon(boundary_points).buffer(0)
-            shape = unary_union([shape, shape_ch])
+            if shape_ch.is_valid:
+                shape = unary_union([shape, shape_ch])
 
         if type(shape) != Polygon:
             shape = max(shape.geoms, key=lambda s: s.area)


### PR DESCRIPTION
I don't know if the code is still maintained but here are several small fixes I introduced to try and run it without CGAL bindings. Putting them here if it can help.

As the libraries versions are not fixed, I stumbled upon compatibilities issues with newer versions of them.

* Numpy has deprecated `np.bool` since `1.24.0`. I replaced it with `bool` as it seems `np.bool` was only an alias on Python `bool` type
* Shapely MultiPolygons need to be accessed through `.geoms` to iterate over them
* Shapely `cascaded_union` is deprecated and will soon be replaced by `unary_union`

I also added two checks to prevent what seem to me as unnecessary breaking exceptions:

* In `compute_shape()` in `fit.py` I noticed that when [@Geodan/concave-hull](https://github.com/Geodan/concave-hull) returns an invalid polygon (it does happen from time to time) the union will break. Added a check to prevent merging alpha shape geometry with invalid concave-hull geometry
* In `triangle_geometry()` in `alpha_shape.py` I encountered some cases where `sqrt()` had to deal with a very small negative number. I added a `try: ... except ValueError: ...` around it and initialized the area value to `0` 
